### PR TITLE
Fix "credential persistence through GitHub Actions artifacts"

### DIFF
--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Zizmor is pretty cool!

Fixes:

```sh
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> deploy-stack.yml:19:9
   |
19 |         - name: Checkout
   |  _________-
20 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

3 findings (2 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 0 high
```

Now, still leaving some suppressed checks to do:

```sh
2024-12-31T11:14:34.185439Z  WARN zizmor: skipping impostor-commit: can't run without a GitHub API token
2024-12-31T11:14:34.185544Z  WARN zizmor: skipping ref-confusion: can't run without a GitHub API token
2024-12-31T11:14:34.185606Z  WARN zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
2024-12-31T11:14:34.189558Z  INFO audit: zizmor: 🌈 completed deploy-stack.yml
No findings to report. Good job! (2 suppressed)
```